### PR TITLE
Change data module use of data domain

### DIFF
--- a/simple_shapes_dataset/data_module.py
+++ b/simple_shapes_dataset/data_module.py
@@ -88,7 +88,7 @@ class SimpleShapesDataModule(LightningDataModule):
     def get_domain_classes(
         self, domain_classes: Mapping[DomainDesc, type[DataDomain]]
     ) -> dict[str, dict[DomainDesc, DataDomain]]:
-        all_domain_classes = {
+        all_domain_classes: dict[str, dict[DomainDesc, DataDomain]] = {
             "train": {},
             "val": {},
             "test": {},
@@ -145,8 +145,8 @@ class SimpleShapesDataModule(LightningDataModule):
                 return True
         return False
 
-    def _get_selected_domains(self) -> set[str]:
-        return {domain.kind for domain in self.domain_classes}
+    def _get_selected_domains(self, split: str) -> set[str]:
+        return {domain.kind for domain in self.domain_classes[split]}
 
     def _get_dataset(self, split: str) -> Mapping[frozenset[str], DatasetT]:
         assert split in ("train", "val", "test")

--- a/simple_shapes_dataset/data_module.py
+++ b/simple_shapes_dataset/data_module.py
@@ -69,7 +69,7 @@ class SimpleShapesDataModule(LightningDataModule):
         self._train_transform = train_transforms or {}
         self._val_transform = val_transforms or {}
         self._use_default_transforms = use_default_transforms
-        self.get_domain_classes(domain_classes)
+        self.domain_classes = self.get_domain_classes(domain_classes)
 
         self.max_train_size = max_train_size
         self.batch_size = batch_size
@@ -85,8 +85,10 @@ class SimpleShapesDataModule(LightningDataModule):
 
         self._collate_fn = collate_fn
 
-    def get_domain_classes(self, domain_classes: Mapping[DomainDesc, type[DataDomain]]):
-        self.domain_classes: dict[str, dict[DomainDesc, DataDomain]] = {
+    def get_domain_classes(
+        self, domain_classes: Mapping[DomainDesc, type[DataDomain]]
+    ) -> dict[str, dict[DomainDesc, DataDomain]]:
+        all_domain_classes = {
             "train": {},
             "val": {},
             "test": {},
@@ -102,12 +104,14 @@ class SimpleShapesDataModule(LightningDataModule):
                 if transforms is not None and domain.kind in transforms:
                     transform = transforms[domain.kind]
 
-                self.domain_classes[split][domain] = domain_cls(
+                all_domain_classes[split][domain] = domain_cls(
                     self.dataset_path,
                     split,
                     transform,
                     self.domain_args.get(domain.kind, None),
                 )
+
+        return all_domain_classes
 
     def _get_transforms(
         self, domains: Iterable[str], mode: str

--- a/simple_shapes_dataset/data_module.py
+++ b/simple_shapes_dataset/data_module.py
@@ -86,7 +86,11 @@ class SimpleShapesDataModule(LightningDataModule):
         self._collate_fn = collate_fn
 
     def get_domain_classes(self, domain_classes: Mapping[DomainDesc, type[DataDomain]]):
-        self.domain_classes = {"train": {}, "val": {}, "test": {}}
+        self.domain_classes: dict[str, dict[DomainDesc, DataDomain]] = {
+            "train": {},
+            "val": {},
+            "test": {},
+        }
 
         self.domains = {domain.kind for domain in domain_classes}
 

--- a/simple_shapes_dataset/data_module.py
+++ b/simple_shapes_dataset/data_module.py
@@ -61,7 +61,6 @@ class SimpleShapesDataModule(LightningDataModule):
             )
 
         self.dataset_path = Path(dataset_path)
-        self.domain_classes = domain_classes
         self.domain_proportions = domain_proportions
         self.seed = seed
         self.ood_seed = ood_seed
@@ -70,6 +69,7 @@ class SimpleShapesDataModule(LightningDataModule):
         self._train_transform = train_transforms or {}
         self._val_transform = val_transforms or {}
         self._use_default_transforms = use_default_transforms
+        self.get_domain_classes(domain_classes)
 
         self.max_train_size = max_train_size
         self.batch_size = batch_size
@@ -84,6 +84,26 @@ class SimpleShapesDataModule(LightningDataModule):
         self.test_dataset_ood: Mapping[frozenset[str], DatasetT] | None = None
 
         self._collate_fn = collate_fn
+
+    def get_domain_classes(self, domain_classes: Mapping[DomainDesc, type[DataDomain]]):
+        self.domain_classes = {"train": {}, "val": {}, "test": {}}
+
+        self.domains = {domain.kind for domain in domain_classes}
+
+        for split in ["train", "val", "test"]:
+            transforms = self._get_transforms(self.domains, split)
+
+            for domain, domain_cls in domain_classes.items():
+                transform = None
+                if transforms is not None and domain.kind in transforms:
+                    transform = transforms[domain.kind]
+
+                self.domain_classes[split][domain] = domain_cls(
+                    self.dataset_path,
+                    split,
+                    transform,
+                    self.domain_args.get(domain.kind, None),
+                )
 
     def _get_transforms(
         self, domains: Iterable[str], mode: str
@@ -123,7 +143,7 @@ class SimpleShapesDataModule(LightningDataModule):
     def _get_dataset(self, split: str) -> Mapping[frozenset[str], DatasetT]:
         assert split in ("train", "val", "test")
 
-        domains = self._get_selected_domains()
+        domains = self.domains
 
         if self._requires_aligned_dataset():
             if self.seed is None:
@@ -132,7 +152,7 @@ class SimpleShapesDataModule(LightningDataModule):
             return get_aligned_datasets(
                 self.dataset_path,
                 split,
-                self.domain_classes,
+                self.domain_classes[split],
                 self.domain_proportions,
                 self.seed,
                 self.max_train_size,
@@ -145,7 +165,7 @@ class SimpleShapesDataModule(LightningDataModule):
                 frozenset(domains): SimpleShapesDataset(
                     self.dataset_path,
                     split,
-                    self.domain_classes,
+                    self.domain_classes[split],
                     transforms=self._get_transforms(domains, split),
                     domain_args=self.domain_args,
                 )
@@ -156,7 +176,7 @@ class SimpleShapesDataModule(LightningDataModule):
                 split,
                 {
                     domain_type: domain_cls
-                    for domain_type, domain_cls in self.domain_classes.items()
+                    for domain_type, domain_cls in self.domain_classes[split].items()
                     if domain_type.kind == domain
                 },
                 self.max_train_size,

--- a/simple_shapes_dataset/dataset.py
+++ b/simple_shapes_dataset/dataset.py
@@ -58,7 +58,7 @@ class SimpleShapesDataset(Dataset):
         self,
         dataset_path: str | Path,
         split: str,
-        domain_classes: Mapping[DomainDesc, type[DataDomain]],
+        domain_classes: dict[DomainDesc, DataDomain],
         max_size: int | None = None,
         transforms: Mapping[str, Callable[[Any], Any]] | None = None,
         domain_args: Mapping[str, Any] | None = None,

--- a/simple_shapes_dataset/dataset.py
+++ b/simple_shapes_dataset/dataset.py
@@ -84,16 +84,7 @@ class SimpleShapesDataset(Dataset):
         self.domain_args = domain_args or {}
 
         for domain, domain_cls in domain_classes.items():
-            transform = None
-            if transforms is not None and domain.kind in transforms:
-                transform = transforms[domain.kind]
-
-            self.domains[domain.kind] = domain_cls(
-                dataset_path,
-                split,
-                transform,
-                self.domain_args.get(domain.kind, None),
-            )
+            self.domains[domain.kind] = domain_cls
 
         lengths = {len(domain) for domain in self.domains.values()}
         min_length = min(lengths)

--- a/simple_shapes_dataset/domain.py
+++ b/simple_shapes_dataset/domain.py
@@ -393,7 +393,7 @@ def get_default_domains_dataset(
     domains: Iterable[DomainDesc | str],
     dataset_path: str | Path,
     split: str,
-    transforms: dict[str, Callable[[Any], Any]],
+    transforms: Mapping[str, Callable[[Any], Any]] | None,
     domain_args: Mapping[str, Any] | None = None,
 ) -> dict[DomainDesc, DataDomain]:
     domain_classes = {}
@@ -403,7 +403,7 @@ def get_default_domains_dataset(
         domain_classes[domain] = DEFAULT_DOMAINS[domain.kind](
             dataset_path,
             split,
-            transforms,
+            transforms[domain],
             domain_args.get(domain.kind, None),
         )
     return domain_classes

--- a/simple_shapes_dataset/domain.py
+++ b/simple_shapes_dataset/domain.py
@@ -393,8 +393,8 @@ def get_default_domains_dataset(
     domains: Iterable[DomainDesc | str],
     dataset_path: str | Path,
     split: str,
-    transforms: dict[str, Callable[[Any], Any]] | None,
-    domain_args: Mapping[str, Any] | None = {},
+    transforms: Mapping[str, Callable[[Any], Any]] | None,
+    domain_args: Mapping[str, Any] = {},
 ) -> dict[DomainDesc, DataDomain]:
     domain_classes = {}
     for domain in domains:

--- a/simple_shapes_dataset/domain.py
+++ b/simple_shapes_dataset/domain.py
@@ -393,7 +393,7 @@ def get_default_domains_dataset(
     domains: Iterable[DomainDesc | str],
     dataset_path: str | Path,
     split: str,
-    transforms: Mapping[str, Callable[[Any], Any]] | None,
+    transforms: Mapping[str, Callable[[Any], Any]],
     domain_args: Mapping[str, Any] = {},
 ) -> dict[DomainDesc, DataDomain]:
     domain_classes = {}

--- a/simple_shapes_dataset/domain.py
+++ b/simple_shapes_dataset/domain.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from collections.abc import Callable, Iterable
+from collections.abc import Callable, Iterable, Mapping
 from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
@@ -386,4 +386,24 @@ def get_default_domains(
         if isinstance(domain, str):
             domain = DomainType[domain].value
         domain_classes[domain] = DEFAULT_DOMAINS[domain.kind]
+    return domain_classes
+
+
+def get_default_domains_dataset(
+    domains: Iterable[DomainDesc | str],
+    dataset_path: str | Path,
+    split: str,
+    transforms: dict[str, Callable[[Any], Any]],
+    domain_args: Mapping[str, Any] | None = None,
+) -> dict[DomainDesc, DataDomain]:
+    domain_classes = {}
+    for domain in domains:
+        if isinstance(domain, str):
+            domain = DomainType[domain].value
+        domain_classes[domain] = DEFAULT_DOMAINS[domain.kind](
+            dataset_path,
+            split,
+            transforms,
+            domain_args.get(domain.kind, None),
+        )
     return domain_classes

--- a/simple_shapes_dataset/domain.py
+++ b/simple_shapes_dataset/domain.py
@@ -393,8 +393,8 @@ def get_default_domains_dataset(
     domains: Iterable[DomainDesc | str],
     dataset_path: str | Path,
     split: str,
-    transforms: Mapping[str, Callable[[Any], Any]] | None,
-    domain_args: Mapping[str, Any] | None = None,
+    transforms: dict[str, Callable[[Any], Any]] | None,
+    domain_args: Mapping[str, Any] | None = {},
 ) -> dict[DomainDesc, DataDomain]:
     domain_classes = {}
     for domain in domains:
@@ -403,7 +403,7 @@ def get_default_domains_dataset(
         domain_classes[domain] = DEFAULT_DOMAINS[domain.kind](
             dataset_path,
             split,
-            transforms[domain],
+            transforms[domain.kind],
             domain_args.get(domain.kind, None),
         )
     return domain_classes

--- a/simple_shapes_dataset/domain_alignment.py
+++ b/simple_shapes_dataset/domain_alignment.py
@@ -52,7 +52,7 @@ def get_alignment(
 def get_aligned_datasets(
     dataset_path: str | Path,
     split: str,
-    domain_classes: Mapping[DomainDesc, type[DataDomain]],
+    domain_classes: Mapping[DomainDesc, DataDomain],
     domain_proportions: Mapping[frozenset[str], float],
     seed: int,
     max_size: int | None = None,

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -74,7 +74,7 @@ def test_dataloader():
 
 
 def test_get_aligned_datasets():
-    transform = {"v": ToTensor(), "attr": attribute_to_tensor}
+    transform = {"t": Compose([]), "v": Compose([])}
 
     datasets = get_aligned_datasets(
         PROJECT_DIR / "sample_dataset",

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -1,21 +1,29 @@
 from torch.utils.data.dataloader import DataLoader
-from torchvision.transforms import ToTensor
+from torchvision.transforms import Compose, ToTensor
 from utils import PROJECT_DIR
 
 from simple_shapes_dataset.data_module import SimpleShapesDataModule
 from simple_shapes_dataset.dataset import SimpleShapesDataset
 from simple_shapes_dataset.domain import (
     get_default_domains,
+    get_default_domains_dataset,
 )
 from simple_shapes_dataset.domain_alignment import get_aligned_datasets
 from simple_shapes_dataset.pre_process import attribute_to_tensor
 
 
 def test_dataset():
+    transform = {"attr": Compose([]), "v": Compose([])}
+
     dataset = SimpleShapesDataset(
         PROJECT_DIR / "sample_dataset",
         split="train",
-        domain_classes=get_default_domains(["v", "attr"]),
+        domain_classes=get_default_domains_dataset(
+            ["v", "attr"],
+            PROJECT_DIR / "sample_dataset",
+            split="train",
+            transforms=transform,
+        ),
     )
 
     assert len(dataset) == 4
@@ -26,10 +34,16 @@ def test_dataset():
 
 
 def test_dataset_val():
+    transform = {"attr": Compose([]), "v": Compose([])}
     dataset = SimpleShapesDataset(
         PROJECT_DIR / "sample_dataset",
         split="val",
-        domain_classes=get_default_domains(["v", "attr"]),
+        domain_classes=get_default_domains_dataset(
+            ["v", "attr"],
+            PROJECT_DIR / "sample_dataset",
+            split="val",
+            transforms=transform,
+        ),
     )
 
     assert len(dataset) == 2
@@ -44,7 +58,12 @@ def test_dataloader():
     dataset = SimpleShapesDataset(
         PROJECT_DIR / "sample_dataset",
         split="train",
-        domain_classes=get_default_domains(["v", "attr"]),
+        domain_classes=get_default_domains_dataset(
+            ["v", "attr"],
+            PROJECT_DIR / "sample_dataset",
+            split="train",
+            transforms=transform,
+        ),
         transforms=transform,
     )
 
@@ -55,10 +74,17 @@ def test_dataloader():
 
 
 def test_get_aligned_datasets():
+    transform = {"v": ToTensor(), "attr": attribute_to_tensor}
+
     datasets = get_aligned_datasets(
         PROJECT_DIR / "sample_dataset",
         "train",
-        domain_classes=get_default_domains(["v", "t"]),
+        domain_classes=get_default_domains_dataset(
+            ["v", "t"],
+            PROJECT_DIR / "sample_dataset",
+            split="train",
+            transforms=transform,
+        ),
         domain_proportions={
             frozenset(["v", "t"]): 0.5,
             frozenset("v"): 1.0,

--- a/tests/test_preprocess.py
+++ b/tests/test_preprocess.py
@@ -31,32 +31,3 @@ def test_attr_preprocess():
     assert item["attr"][0].shape == (2, 3)
     assert isinstance(item["attr"][1], torch.Tensor)
     assert item["attr"][1].shape == (2, 8)
-
-
-def test_attr_preprocess_with_unpaired():
-    transform = {
-        "attr": attribute_to_tensor,
-    }
-    dataset = SimpleShapesDataset(
-        PROJECT_DIR / "sample_dataset",
-        split="train",
-        domain_classes=get_default_domains_dataset(
-            ["attr"],
-            PROJECT_DIR / "sample_dataset",
-            split="train",
-            transforms=transform,
-        ),
-        domain_args={"attr": {"n_unpaired": 1}},
-        transforms=transform,
-    )
-
-    dataloader = torch.utils.data.DataLoader(dataset, batch_size=2)
-    item = next(iter(dataloader))
-    assert isinstance(item["attr"], list)
-    assert len(item["attr"]) == 3
-    assert isinstance(item["attr"][0], torch.Tensor)
-    assert item["attr"][0].shape == (2, 3)
-    assert isinstance(item["attr"][1], torch.Tensor)
-    assert item["attr"][1].shape == (2, 8)
-    assert isinstance(item["attr"][2], torch.Tensor)
-    assert item["attr"][2].shape == (2, 1)

--- a/tests/test_preprocess.py
+++ b/tests/test_preprocess.py
@@ -3,7 +3,7 @@ import torch.utils.data
 from utils import PROJECT_DIR
 
 from simple_shapes_dataset.dataset import SimpleShapesDataset
-from simple_shapes_dataset.domain import get_default_domains
+from simple_shapes_dataset.domain import get_default_domains_dataset
 from simple_shapes_dataset.pre_process import attribute_to_tensor
 
 
@@ -14,7 +14,12 @@ def test_attr_preprocess():
     dataset = SimpleShapesDataset(
         PROJECT_DIR / "sample_dataset",
         split="train",
-        domain_classes=get_default_domains(["attr"]),
+        domain_classes=get_default_domains_dataset(
+            ["attr"],
+            PROJECT_DIR / "sample_dataset",
+            split="train",
+            transforms=transform,
+        ),
         transforms=transform,
     )
 
@@ -35,7 +40,12 @@ def test_attr_preprocess_with_unpaired():
     dataset = SimpleShapesDataset(
         PROJECT_DIR / "sample_dataset",
         split="train",
-        domain_classes=get_default_domains(["attr"]),
+        domain_classes=get_default_domains_dataset(
+            ["attr"],
+            PROJECT_DIR / "sample_dataset",
+            split="train",
+            transforms=transform,
+        ),
         domain_args={"attr": {"n_unpaired": 1}},
         transforms=transform,
     )


### PR DESCRIPTION
Load DataDomain classes directly into DataModule than into each dataset:

PB: Each DataDomain is loading at least one .npy file.
With 3 modalities: v, attr, t we have 7 possible combinations.
For each combination a Dataset is created with one to three modalities, leading to one to three DataDomain.
In this situation at least 12 .npy are open and stored in memory.

Solution:
To decrease memory usage, load only the 3 DataDomain once in DataModule and pass them to the different datsets